### PR TITLE
Initialize double before reading + unifying

### DIFF
--- a/redis4pl.c
+++ b/redis4pl.c
@@ -463,7 +463,7 @@ redis_read_stream(IOSTREAM *in, term_t message, term_t push)
       break;
     }
     case ',':				/* RESP3 double response */
-    { double v;
+    { double v = 0.0;
 
       rc = ( read_double(in, &cb, &v) &&
 	     PL_unify_float(message, v) );


### PR DESCRIPTION
```
$ gcc --version
gcc (Debian 8.3.0-6) 8.3.0
```

Snip from the `ninja` output before the patch:
```
../packages/redis/redis4pl.c: In function ‘redis_read_stream’:
../packages/redis/redis4pl.c:469:7: warning: ‘v’ may be used uninitialized in this function [-Wmaybe-uninitialized]
       PL_unify_float(message, v) );
       ^~~~~~~~~~~~~~~~~~~~~~~~~~
```